### PR TITLE
add mints to swap event

### DIFF
--- a/programs/gamma/src/instructions/swap_base_input.rs
+++ b/programs/gamma/src/instructions/swap_base_input.rs
@@ -419,6 +419,8 @@ pub fn swap_base_input<'c, 'info>(
             Ok(value) => value,
             Err(_) => return err!(GammaError::MathOverflow),
         },
+        input_mint: ctx.accounts.input_vault.mint,
+        output_mint: ctx.accounts.output_vault.mint,
         input_transfer_fee,
         output_transfer_fee,
         base_input: true,

--- a/programs/gamma/src/instructions/swap_base_output.rs
+++ b/programs/gamma/src/instructions/swap_base_output.rs
@@ -322,6 +322,8 @@ pub fn swap_base_output<'c, 'info>(
             Ok(value) => value,
             Err(_) => return err!(GammaError::MathOverflow),
         },
+        input_mint: ctx.accounts.input_vault.mint,
+        output_mint: ctx.accounts.output_vault.mint,
         input_transfer_fee,
         output_transfer_fee,
         base_input: false,

--- a/programs/gamma/src/states/events.rs
+++ b/programs/gamma/src/states/events.rs
@@ -31,20 +31,24 @@ pub struct LpChangeEvent {
 pub struct SwapEvent {
     #[index]
     pub pool_id: Pubkey,
-    // pool vault - trade_fees
+    /// pool vault - trade_fees
     pub input_vault_before: u64,
-    // pool_vault - trade_fees
+    /// pool_vault - trade_fees
     pub output_vault_before: u64,
-    // calculate result without transfer fees
+    /// calculate result without transfer fees
     pub input_amount: u64,
-    // calculate result without transfer fees
+    /// calculate result without transfer fees
     pub output_amount: u64,
-    // transfer fees on input token using token extensions
+    /// input mint for the swap
+    pub input_mint: Pubkey,
+    /// output mint for the swap
+    pub output_mint: Pubkey,
+    /// transfer fees on input token using token extensions
     pub input_transfer_fee: u64,
-    // transfer fees on output token using token extensions
+    /// transfer fees on output token using token extensions
     pub output_transfer_fee: u64,
     pub base_input: bool,
-    // dynamic_fees after this swap
+    /// dynamic_fees after this swap
     pub dynamic_fee: u128,
 }
 


### PR DESCRIPTION
Most important feature for indexers is being able to get `input-mint, output-mint, input-amount, and output-amount` directly from tx logs